### PR TITLE
feat: add 'sanitize' config option

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -70,7 +70,7 @@ suffix: string
 
 ## PhraseConfig
 
-Type describing all possible **Phrase In-Context Editor** config options.
+Type describing all possible **Phrase In-Context Editor** config options. Further details [here](https://help.phrase.com/help/configure-in-context-editor).
 
 ```typescript
 phraseEnabled: boolean;
@@ -104,4 +104,5 @@ sso: {
     identifier: string;
 };
 fullReparse: boolean = true;
+sanitize?: (content: string) => string;
 ```

--- a/src/phrase-config.type.ts
+++ b/src/phrase-config.type.ts
@@ -30,4 +30,5 @@ export type PhraseConfig = {
         identifier: string;
     };
     fullReparse: boolean;
+    sanitize?: (content: string)=> string;
 };


### PR DESCRIPTION
Add support for optional 'sanitize' configuration option, which can be used to sanitize translation data before it is put into the DOM.

