### PR TITLE
INTEGRATE-1434: fix dependabot not releasing

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,10 @@
 module.exports = {
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        ["@semantic-release/commit-analyzer", {
+            "releaseRules": [
+                {"type": "chore", "scope": "deps", "release": "patch"}
+            ]
+        }],
         "@semantic-release/release-notes-generator",
         "@semantic-release/changelog",
         ["@semantic-release/npm", {


### PR DESCRIPTION
By default semantic-release will only do a new release of the package
if the commit contains a "feat" or "fix" prefix. This meant that
merging dependabot changes never caused a new build to be triggered.

This adds config that specifically will trigger a release from
a dependabot change.