### PR TITLE
fix(TSE-1157): Improve US datacenter documentation and typings

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -110,7 +110,7 @@ Go and checkout [`examples/vue3` directory of **Vue I18n Phrase In-Context Edito
 
 ## Using the US Datacenter with ICE
 
-In addition to `phraseEnabled` and `projectId` in the config, also set the US datacenter to enable working through the US endpoints.
+In addition to the settings in your config, set the US datacenter to enable it working with the US endpoints.
 ```js
   datacenter: 'us'
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -110,10 +110,7 @@ Go and checkout [`examples/vue3` directory of **Vue I18n Phrase In-Context Edito
 
 ## Using the US Datacenter with ICE
 
-In addition to `phraseEnabled` and `projectId` in the config, also add the US specific URLs to enable working through the US endpoint.
-```
-  baseUrl: "https://us.app.phrase.com",
-  apiBaseUrl: 'https://api.us.app.phrase.com/api/v2',
-  oauthEndpointUrl: "https://api.us.app.phrase.com/api/v2/authorizations",
-  profileUrl: "https://us.app.phrase.com/settings/profile",
+In addition to `phraseEnabled` and `projectId` in the config, also set the US datacenter to enable working through the US endpoints.
+```js
+  datacenter: 'us'
 ```

--- a/src/phrase-config.type.ts
+++ b/src/phrase-config.type.ts
@@ -20,6 +20,7 @@ export type PhraseConfig = {
     useOldICE: boolean;
     forceLocale: boolean;
     loginDialogMessage: string;
+    datacenter: 'eu' | 'us';
     autoLogin: {
         perform: boolean;
         email: string;


### PR DESCRIPTION
- Instructions for US DC were incorrect
- Typings didn't support datacenter attribute

https://phrase.atlassian.net/browse/TSE-1157