### PR TITLE
chore: Close inactive issues

### DIFF
--- a/.github/workflows/close_inactive_issues.yml
+++ b/.github/workflows/close_inactive_issues.yml
@@ -1,0 +1,18 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 7
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "Hey! This issue is still open, but there hasn't been any activity for a week now, so we will be marking this issue as stale and closing it in a week if it's still inactive."
+          close-issue-message: "This issue was closed because it has been inactive for one week since being marked as stale."


### PR DESCRIPTION
Rule: A reminder is sent after 1 week. After another week of inactivity, the issue is closed.
Github docs: https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues

cron job is set up to run once a day