### PR TITLE
fix: adjust Github workflow to use Node v20

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 20
           registry-url: 'https://npm.pkg.github.com'
 
       - uses: pnpm/action-setup@v2.4.0


### PR DESCRIPTION
To adjust Github workflow to use Node v20

Node 16 actions are deprecated: https://github.com/phrase/vue-i18n-phrase-in-context-editor/actions/runs/7985808689