### PR TITLE
chore(deps-dev): bump elliptic from 6.5.4 to 6.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@vue/test-utils": "1.0.0-beta.31",
     "@vue/vue2-jest": "^29.2.6",
     "babel-jest": "^29.7.0",
+    "elliptic": "^6.6.1",
     "eslint": "^8.54.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-vue": "^9.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,52 +29,55 @@ importers:
         version: 1.17.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.12.0
-        version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@4.3.5)
+        version: 6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)(typescript@4.3.5)
       '@typescript-eslint/parser':
         specifier: ^6.12.0
         version: 6.12.0(eslint@8.54.0)(typescript@4.3.5)
       '@vue/cli-plugin-babel':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8)(core-js@3.33.3)(vue@2.6.11)
+        version: 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(core-js@3.33.3)(vue@2.6.11)
       '@vue/cli-plugin-eslint':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8)(eslint@8.54.0)
+        version: 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint@8.54.0)
       '@vue/cli-plugin-typescript':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8)(eslint@8.54.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
+        version: 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint@8.54.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
       '@vue/cli-plugin-unit-jest':
         specifier: ~5.0.8
-        version: 5.0.8(@vue/cli-service@5.0.8)(@vue/vue2-jest@29.2.6)(jest@29.7.0)(ts-jest@29.1.1)
+        version: 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(@vue/vue2-jest@29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0(@babel/core@7.18.6))(handlebars@4.7.8)(jest@29.7.0(@types/node@20.9.4))(lodash@4.17.21)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11))(jest@29.7.0(@types/node@20.9.4))(ts-jest@29.1.1(@babel/core@7.18.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.6))(jest@29.7.0(@types/node@20.9.4))(typescript@4.3.5))
       '@vue/cli-service':
         specifier: ~5.0.8
-        version: 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+        version: 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/eslint-config-airbnb':
         specifier: ^5.0.2
-        version: 5.0.2(@vue/cli-service@5.0.8)(eslint-plugin-import@2.29.0)(eslint@8.54.0)(webpack@5.89.0)
+        version: 5.0.2(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(eslint@8.54.0)(webpack@5.89.0)
       '@vue/eslint-config-typescript':
         specifier: ^5.0.2
-        version: 5.0.2(@typescript-eslint/eslint-plugin@6.12.0)(@typescript-eslint/parser@6.12.0)(eslint-plugin-vue@9.18.1)(eslint@8.54.0)(typescript@4.3.5)
+        version: 5.0.2(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)(typescript@4.3.5))(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint-plugin-vue@9.18.1(eslint@8.54.0))(eslint@8.54.0)(typescript@4.3.5)
       '@vue/test-utils':
         specifier: 1.0.0-beta.31
         version: 1.0.0-beta.31(vue-template-compiler@2.6.11)(vue@2.6.11)
       '@vue/vue2-jest':
         specifier: ^29.2.6
-        version: 29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
+        version: 29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0(@babel/core@7.18.6))(handlebars@4.7.8)(jest@29.7.0(@types/node@20.9.4))(lodash@4.17.21)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.18.6)
+      elliptic:
+        specifier: ^6.6.1
+        version: 6.6.1
       eslint:
         specifier: ^8.54.0
         version: 8.54.0
       eslint-plugin-import:
         specifier: ^2.29.0
-        version: 2.29.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)
+        version: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)
       eslint-plugin-vue:
         specifier: ^9.18.1
         version: 9.18.1(eslint@8.54.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.9.4)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -83,7 +86,7 @@ importers:
         version: 19.0.5
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.1(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5)
+        version: 29.1.1(@babel/core@7.18.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.6))(jest@29.7.0(@types/node@20.9.4))(typescript@4.3.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@4.3.5)(webpack@5.89.0)
@@ -2818,8 +2821,8 @@ packages:
   electron-to-chromium@1.4.590:
     resolution: {integrity: sha512-hohItzsQcG7/FBsviCYMtQwUSWvVF7NVqPOnJCErWsAshsP/CR2LAXdmq276RbESNdhxiAq5/vRo1g2pxGXVww==}
 
-  elliptic@6.5.4:
-    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emittery@0.10.2:
     resolution: {integrity: sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==}
@@ -7939,7 +7942,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 15.0.0
 
-  '@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@4.3.5)':
+  '@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)(typescript@4.3.5)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
@@ -7954,6 +7957,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@4.3.5)
+    optionalDependencies:
       typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -7966,6 +7970,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.12.0
       debug: 4.3.4
       eslint: 8.54.0
+    optionalDependencies:
       typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -7982,6 +7987,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.54.0
       ts-api-utils: 1.0.3(typescript@4.3.5)
+    optionalDependencies:
       typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -7997,6 +8003,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@4.3.5)
+    optionalDependencies:
       typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
@@ -8066,9 +8073,10 @@ snapshots:
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.18.6)
       '@vue/babel-preset-jsx': 1.1.2(@babel/core@7.18.6)
       babel-plugin-dynamic-import-node: 2.3.3
-      core-js: 3.33.3
       core-js-compat: 3.33.3
       semver: 7.3.7
+    optionalDependencies:
+      core-js: 3.33.3
       vue: 2.6.11
     transitivePeerDependencies:
       - supports-color
@@ -8112,11 +8120,11 @@ snapshots:
 
   '@vue/cli-overlay@5.0.8': {}
 
-  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8)(core-js@3.33.3)(vue@2.6.11)':
+  '@vue/cli-plugin-babel@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(core-js@3.33.3)(vue@2.6.11)':
     dependencies:
       '@babel/core': 7.18.6
       '@vue/babel-preset-app': 5.0.8(@babel/core@7.18.6)(core-js@3.33.3)(vue@2.6.11)
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
       babel-loader: 8.3.0(@babel/core@7.18.6)(webpack@5.89.0)
       thread-loader: 3.0.4(webpack@5.89.0)
@@ -8131,9 +8139,9 @@ snapshots:
       - vue
       - webpack-cli
 
-  '@vue/cli-plugin-eslint@5.0.8(@vue/cli-service@5.0.8)(eslint@8.54.0)':
+  '@vue/cli-plugin-eslint@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint@8.54.0)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
       eslint: 8.54.0
       eslint-webpack-plugin: 3.2.0(eslint@8.54.0)(webpack@5.89.0)
@@ -8147,18 +8155,18 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8)':
+  '@vue/cli-plugin-router@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
     transitivePeerDependencies:
       - encoding
 
-  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8)(eslint@8.54.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)':
+  '@vue/cli-plugin-typescript@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint@8.54.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)':
     dependencies:
       '@babel/core': 7.18.6
       '@types/webpack-env': 1.17.0
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
       babel-loader: 8.3.0(@babel/core@7.18.6)(webpack@5.89.0)
       fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.54.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(webpack@5.89.0)
@@ -8167,8 +8175,9 @@ snapshots:
       ts-loader: 9.5.1(typescript@4.3.5)(webpack@5.89.0)
       typescript: 4.3.5
       vue: 2.6.11
-      vue-template-compiler: 2.6.11
       webpack: 5.89.0
+    optionalDependencies:
+      vue-template-compiler: 2.6.11
     transitivePeerDependencies:
       - '@swc/core'
       - encoding
@@ -8178,41 +8187,42 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@vue/cli-plugin-unit-jest@5.0.8(@vue/cli-service@5.0.8)(@vue/vue2-jest@29.2.6)(jest@29.7.0)(ts-jest@29.1.1)':
+  '@vue/cli-plugin-unit-jest@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(@vue/vue2-jest@29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0(@babel/core@7.18.6))(handlebars@4.7.8)(jest@29.7.0(@types/node@20.9.4))(lodash@4.17.21)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11))(jest@29.7.0(@types/node@20.9.4))(ts-jest@29.1.1(@babel/core@7.18.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.6))(jest@29.7.0(@types/node@20.9.4))(typescript@4.3.5))':
     dependencies:
       '@babel/core': 7.18.6
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.18.6)
       '@types/jest': 27.5.2
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       '@vue/cli-shared-utils': 5.0.8
-      '@vue/vue2-jest': 29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
       babel-jest: 27.5.1(@babel/core@7.18.6)
       deepmerge: 4.2.2
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.9.4)
       jest-serializer-vue: 2.0.2
       jest-transform-stub: 2.0.0
-      jest-watch-typeahead: 1.1.0(jest@29.7.0)
-      ts-jest: 29.1.1(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5)
+      jest-watch-typeahead: 1.1.0(jest@29.7.0(@types/node@20.9.4))
+    optionalDependencies:
+      '@vue/vue2-jest': 29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0(@babel/core@7.18.6))(handlebars@4.7.8)(jest@29.7.0(@types/node@20.9.4))(lodash@4.17.21)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      ts-jest: 29.1.1(@babel/core@7.18.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.6))(jest@29.7.0(@types/node@20.9.4))(typescript@4.3.5)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8)':
+  '@vue/cli-plugin-vuex@5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))':
     dependencies:
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
 
-  '@vue/cli-service@5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)':
+  '@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)':
     dependencies:
       '@babel/helper-compilation-targets': 7.18.6(@babel/core@7.18.6)
       '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@5.89.0)
       '@soda/get-current-script': 1.0.2
       '@types/minimist': 1.2.0
       '@vue/cli-overlay': 5.0.8
-      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8)
-      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8)
+      '@vue/cli-plugin-router': 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))
+      '@vue/cli-plugin-vuex': 5.0.8(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))
       '@vue/cli-shared-utils': 5.0.8
-      '@vue/component-compiler-utils': 3.3.0
-      '@vue/vue-loader-v15': vue-loader@15.11.1(css-loader@6.8.1)(vue-template-compiler@2.6.11)(webpack@5.89.0)
+      '@vue/component-compiler-utils': 3.3.0(handlebars@4.7.8)(lodash@4.17.21)
+      '@vue/vue-loader-v15': vue-loader@15.11.1(css-loader@6.8.1(webpack@5.89.0))(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(webpack@5.89.0)
       '@vue/web-component-wrapper': 1.3.0
       acorn: 8.11.2
       acorn-walk: 8.3.0
@@ -8251,7 +8261,6 @@ snapshots:
       thread-loader: 3.0.4(webpack@5.89.0)
       vue-loader: 17.3.1(vue@2.6.11)(webpack@5.89.0)
       vue-style-loader: 4.1.3
-      vue-template-compiler: 2.6.11
       webpack: 5.89.0
       webpack-bundle-analyzer: 4.10.1
       webpack-chain: 6.5.1
@@ -8259,6 +8268,9 @@ snapshots:
       webpack-merge: 5.10.0
       webpack-virtual-modules: 0.4.6
       whatwg-fetch: 3.6.19
+    optionalDependencies:
+      vue-template-compiler: 2.6.11
+      webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@parcel/css'
@@ -8346,9 +8358,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@vue/component-compiler-utils@3.3.0':
+  '@vue/component-compiler-utils@3.3.0(handlebars@4.7.8)(lodash@4.17.21)':
     dependencies:
-      consolidate: 0.15.1
+      consolidate: 0.15.1(handlebars@4.7.8)(lodash@4.17.21)
       hash-sum: 1.0.2
       lru-cache: 4.1.5
       merge-source-map: 1.1.0
@@ -8413,26 +8425,27 @@ snapshots:
       - walrus
       - whiskers
 
-  '@vue/eslint-config-airbnb@5.0.2(@vue/cli-service@5.0.8)(eslint-plugin-import@2.29.0)(eslint@8.54.0)(webpack@5.89.0)':
+  '@vue/eslint-config-airbnb@5.0.2(@vue/cli-service@5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(eslint@8.54.0)(webpack@5.89.0)':
     dependencies:
-      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(vue-template-compiler@2.6.11)(vue@2.6.11)
+      '@vue/cli-service': 5.0.8(@babel/core@7.18.6)(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(vue@2.6.11)(webpack-sources@3.2.3)
       eslint: 8.54.0
-      eslint-config-airbnb-base: 14.1.0(eslint-plugin-import@2.29.0)(eslint@8.54.0)
+      eslint-config-airbnb-base: 14.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(eslint@8.54.0)
       eslint-import-resolver-node: 0.3.3
-      eslint-import-resolver-webpack: 0.11.1(eslint-plugin-import@2.29.0)(webpack@5.89.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)
+      eslint-import-resolver-webpack: 0.11.1(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(webpack@5.89.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@vue/eslint-config-typescript@5.0.2(@typescript-eslint/eslint-plugin@6.12.0)(@typescript-eslint/parser@6.12.0)(eslint-plugin-vue@9.18.1)(eslint@8.54.0)(typescript@4.3.5)':
+  '@vue/eslint-config-typescript@5.0.2(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)(typescript@4.3.5))(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint-plugin-vue@9.18.1(eslint@8.54.0))(eslint@8.54.0)(typescript@4.3.5)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@4.3.5)
+      '@typescript-eslint/eslint-plugin': 6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)(typescript@4.3.5)
       '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
       eslint: 8.54.0
       eslint-plugin-vue: 9.18.1(eslint@8.54.0)
-      typescript: 4.3.5
       vue-eslint-parser: 7.1.0(eslint@8.54.0)
+    optionalDependencies:
+      typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
@@ -8444,20 +8457,21 @@ snapshots:
       vue: 2.6.11
       vue-template-compiler: 2.6.11
 
-  '@vue/vue2-jest@29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)':
+  '@vue/vue2-jest@29.2.6(@babel/core@7.18.6)(babel-jest@29.7.0(@babel/core@7.18.6))(handlebars@4.7.8)(jest@29.7.0(@types/node@20.9.4))(lodash@4.17.21)(typescript@4.3.5)(vue-template-compiler@2.6.11)(vue@2.6.11)':
     dependencies:
       '@babel/core': 7.18.6
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.18.6)
-      '@vue/component-compiler-utils': 3.3.0
+      '@vue/component-compiler-utils': 3.3.0(handlebars@4.7.8)(lodash@4.17.21)
       babel-jest: 29.7.0(@babel/core@7.18.6)
       chalk: 2.4.2
       css-tree: 2.3.1
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.9.4)
       source-map: 0.5.6
       tsconfig: 7.0.0
-      typescript: 4.3.5
       vue: 2.6.11
       vue-template-compiler: 2.6.11
+    optionalDependencies:
+      typescript: 4.3.5
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -8657,7 +8671,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-keywords@3.4.1(ajv@6.12.2):
@@ -9044,7 +9058,7 @@ snapshots:
       browserify-rsa: 4.0.1
       create-hash: 1.2.0
       create-hmac: 1.1.7
-      elliptic: 6.5.4
+      elliptic: 6.6.1
       inherits: 2.0.4
       parse-asn1: 5.1.5
       readable-stream: 3.6.0
@@ -9312,9 +9326,12 @@ snapshots:
 
   console-browserify@1.2.0: {}
 
-  consolidate@0.15.1:
+  consolidate@0.15.1(handlebars@4.7.8)(lodash@4.17.21):
     dependencies:
       bluebird: 3.7.2
+    optionalDependencies:
+      handlebars: 4.7.8
+      lodash: 4.17.21
 
   constants-browserify@1.0.0: {}
 
@@ -9407,7 +9424,7 @@ snapshots:
   create-ecdh@4.0.3:
     dependencies:
       bn.js: 4.12.0
-      elliptic: 6.5.4
+      elliptic: 6.6.1
 
   create-hash@1.2.0:
     dependencies:
@@ -9426,7 +9443,7 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0:
+  create-jest@29.7.0(@types/node@20.9.4):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
@@ -9788,7 +9805,7 @@ snapshots:
 
   electron-to-chromium@1.4.590: {}
 
-  elliptic@6.5.4:
+  elliptic@6.6.1:
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0
@@ -9932,11 +9949,11 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@14.1.0(eslint-plugin-import@2.29.0)(eslint@8.54.0):
+  eslint-config-airbnb-base@14.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(eslint@8.54.0):
     dependencies:
       confusing-browser-globals: 1.0.9
       eslint: 8.54.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)
       object.assign: 4.1.0
       object.entries: 1.1.1
 
@@ -9955,12 +9972,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-webpack@0.11.1(eslint-plugin-import@2.29.0)(webpack@5.89.0):
+  eslint-import-resolver-webpack@0.11.1(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0))(webpack@5.89.0):
     dependencies:
       array-find: 1.0.0
       debug: 2.6.9
       enhanced-resolve: 0.9.1
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0)
       find-root: 1.1.0
       has: 1.0.3
       interpret: 1.2.0
@@ -9972,18 +9989,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.12.0)(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
     dependencies:
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint@8.54.0):
     dependencies:
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -9992,7 +10009,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.12.0)(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@4.3.5))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10002,6 +10019,8 @@ snapshots:
       object.values: 1.1.7
       semver: 6.3.1
       tsconfig-paths: 3.14.2
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@4.3.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10337,7 +10356,7 @@ snapshots:
   flatted@3.2.9: {}
 
   follow-redirects@1.15.3(debug@4.3.4):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.4
 
   for-each@0.3.3:
@@ -10352,7 +10371,6 @@ snapshots:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      eslint: 8.54.0
       fs-extra: 9.0.0
       glob: 7.1.6
       memfs: 3.5.3
@@ -10361,8 +10379,10 @@ snapshots:
       semver: 7.3.7
       tapable: 1.1.3
       typescript: 4.3.5
-      vue-template-compiler: 2.6.11
       webpack: 5.89.0
+    optionalDependencies:
+      eslint: 8.54.0
+      vue-template-compiler: 2.6.11
 
   form-data@4.0.0:
     dependencies:
@@ -10676,12 +10696,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21)(debug@4.3.4):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1(debug@4.3.4)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -11002,13 +11023,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
+  jest-cli@29.7.0(@types/node@20.9.4):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@20.9.4)
       exit: 0.1.2
       import-local: 3.1.0
       jest-config: 29.7.0(@types/node@20.9.4)
@@ -11026,7 +11047,6 @@ snapshots:
       '@babel/core': 7.18.6
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.9.4
       babel-jest: 29.7.0(@babel/core@7.18.6)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -11046,6 +11066,8 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.9.4
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11187,7 +11209,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@27.5.1: {}
@@ -11340,11 +11362,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@1.1.0(jest@29.7.0):
+  jest-watch-typeahead@1.1.0(jest@29.7.0(@types/node@20.9.4)):
     dependencies:
       ansi-escapes: 4.3.1
       chalk: 4.1.2
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.9.4)
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -11392,12 +11414,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0:
+  jest@29.7.0(@types/node@20.9.4):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0
+      jest-cli: 29.7.0(@types/node@20.9.4)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13240,13 +13262,11 @@ snapshots:
     dependencies:
       typescript: 4.3.5
 
-  ts-jest@29.1.1(@babel/core@7.18.6)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.3.5):
+  ts-jest@29.1.1(@babel/core@7.18.6)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.18.6))(jest@29.7.0(@types/node@20.9.4))(typescript@4.3.5):
     dependencies:
-      '@babel/core': 7.18.6
-      babel-jest: 29.7.0(@babel/core@7.18.6)
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0
+      jest: 29.7.0(@types/node@20.9.4)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -13254,6 +13274,10 @@ snapshots:
       semver: 7.5.4
       typescript: 4.3.5
       yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.18.6
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.18.6)
 
   ts-loader@9.5.1(typescript@4.3.5)(webpack@5.89.0):
     dependencies:
@@ -13470,16 +13494,17 @@ snapshots:
     dependencies:
       vue: 2.6.11
 
-  vue-loader@15.11.1(css-loader@6.8.1)(vue-template-compiler@2.6.11)(webpack@5.89.0):
+  vue-loader@15.11.1(css-loader@6.8.1(webpack@5.89.0))(handlebars@4.7.8)(lodash@4.17.21)(vue-template-compiler@2.6.11)(webpack@5.89.0):
     dependencies:
-      '@vue/component-compiler-utils': 3.3.0
+      '@vue/component-compiler-utils': 3.3.0(handlebars@4.7.8)(lodash@4.17.21)
       css-loader: 6.8.1(webpack@5.89.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.0
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      vue-template-compiler: 2.6.11
       webpack: 5.89.0
+    optionalDependencies:
+      vue-template-compiler: 2.6.11
     transitivePeerDependencies:
       - arc-templates
       - atpl
@@ -13539,9 +13564,10 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
-      vue: 2.6.11
       watchpack: 2.4.0
       webpack: 5.89.0
+    optionalDependencies:
+      vue: 2.6.11
 
   vue-style-loader@4.1.3:
     dependencies:
@@ -13645,9 +13671,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0
       webpack-dev-middleware: 5.3.3(webpack@5.89.0)
       ws: 8.14.2
+    optionalDependencies:
+      webpack: 5.89.0
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
The [dependabot PR](https://github.com/phrase/vue-i18n-phrase-in-context-editor/pull/131) failed to deploy, so I'm making this one.